### PR TITLE
Updating Support for Swift AceMode Flag

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -5326,7 +5326,7 @@
     "extensions": [
       ".swift"
     ],
-    "aceMode": "text",
+    "aceMode": "swift",
     "codemirrorMode": "swift",
     "codemirrorMimeType": "text/x-swift",
     "languageId": 362


### PR DESCRIPTION
The plugin for gitbook called gitbook-plugin-ace uses this package (language-map) to determine which syntax a file should be. In language-map it is improperly set to "text" even though ace supports a "swift" language mode.

This one liner change allows for that support, it was tested successfully on my end by manually changing the languages.json contents.